### PR TITLE
Design Hub tweaks and bug fixes

### DIFF
--- a/app/Http/Controllers/DesignHubController.php
+++ b/app/Http/Controllers/DesignHubController.php
@@ -3,6 +3,7 @@
 namespace App\Http\Controllers;
 
 use App\Facades\Settings;
+use App\Models\Base\Base;
 use App\Models\Feature\Feature;
 use App\Models\Marking\Marking;
 use App\Models\Rarity;
@@ -36,6 +37,7 @@ class DesignHubController extends Controller {
             'subtypes'          => Subtype::orderBy('sort', 'DESC')->get(),
             'markings'          => $markings,
             'rarity_list'       => $rarities,
+            'bases'             => Base::where('is_visible', 1)->get(),
             'trait_lists'       => self::getDesignHubTraitByCategory($request, $trait_categories),
         ]);
     }

--- a/app/Http/Controllers/DesignHubController.php
+++ b/app/Http/Controllers/DesignHubController.php
@@ -37,7 +37,6 @@ class DesignHubController extends Controller {
             'subtypes'          => Subtype::orderBy('sort', 'DESC')->get(),
             'markings'          => $markings,
             'rarity_list'       => $rarities,
-            'bases'             => Base::where('is_visible', 1)->get(),
             'trait_lists'       => self::getDesignHubTraitByCategory($request, $trait_categories),
         ]);
     }

--- a/app/Http/Controllers/DesignHubController.php
+++ b/app/Http/Controllers/DesignHubController.php
@@ -3,7 +3,6 @@
 namespace App\Http\Controllers;
 
 use App\Facades\Settings;
-use App\Models\Base\Base;
 use App\Models\Feature\Feature;
 use App\Models\Marking\Marking;
 use App\Models\Rarity;

--- a/app/Services/CharacterManager.php
+++ b/app/Services/CharacterManager.php
@@ -1103,7 +1103,7 @@ class CharacterManager extends Service {
             $characterData = Arr::only($data, [
                 'character_category_id',
                 'number', 'slug',
-                'is_chimera', 'base', 'secondary_base'
+                'is_chimera', 'base', 'secondary_base',
             ]);
             $characterData['is_sellable'] = isset($data['is_sellable']);
             $characterData['is_tradeable'] = isset($data['is_tradeable']);

--- a/app/Services/CharacterManager.php
+++ b/app/Services/CharacterManager.php
@@ -1103,12 +1103,14 @@ class CharacterManager extends Service {
             $characterData = Arr::only($data, [
                 'character_category_id',
                 'number', 'slug',
+                'is_chimera', 'base', 'secondary_base'
             ]);
             $characterData['is_sellable'] = isset($data['is_sellable']);
             $characterData['is_tradeable'] = isset($data['is_tradeable']);
             $characterData['is_giftable'] = isset($data['is_giftable']);
             $characterData['sale_value'] = $data['sale_value'] ?? 0;
             $characterData['transferrable_at'] = $data['transferrable_at'] ?? null;
+            $characterData['base'] = (isset($data['is_chimera']) ? $data['base'].'|'.$data['secondary_base'] : $data['base']);
             if ($character->is_myo_slot) {
                 $characterData['name'] = (isset($data['name']) && $data['name']) ? $data['name'] : null;
             }
@@ -1846,7 +1848,7 @@ class CharacterManager extends Service {
         DB::beginTransaction();
 
         try {
-            \Log::info('all_data', $data);
+            //\Log::info('all_data', $data);
             // Clear old markings
             CharacterMarking::where('character_id', $character->id)->delete();
 
@@ -1859,14 +1861,14 @@ class CharacterManager extends Service {
 
                     $is_dominant = $data['is_dominant'][$i] ?? 0;
 
-                    \Log::info('Processing marking', [
+                    /*\Log::info('Processing marking', [
                         'loop'          => $i,
                         'markingId'     => $markingId,
                         'code'          => ($is_dominant ? $temp->dominant : $temp->recessive),
                         'order'         => $temp->order_in_genome ?? 0,
                         'is_dominant'   => $is_dominant,
                         'data'          => $data['side_id'][$i] ?? 0,
-                    ]);
+                    ]);*/
 
                     $marking = CharacterMarking::create([
                         'character_id'  => $character->id,

--- a/app/Services/CharacterManager.php
+++ b/app/Services/CharacterManager.php
@@ -1167,6 +1167,11 @@ class CharacterManager extends Service {
                 $old['transferrable_at'] = $character->transferrable_at;
                 $new['transferrable_at'] = $characterData['transferrable_at'];
             }
+            if ($characterData['base'] != $character->base) {
+                $result[] = 'base';
+                $old['base'] = $character->base;
+                $new['base'] = $characterData['base'];
+            }
 
             if (count($result)) {
                 $character->update($characterData);

--- a/config/lorekeeper/text_pages.php
+++ b/config/lorekeeper/text_pages.php
@@ -28,5 +28,13 @@ return [
         'title' => 'Credits',
         'text'  => 'This page will contain credits for code, art, ect that has been used on your site!',
     ],
+    'dh-start' => [
+        'title' => 'Design Hub Start',
+        'text'  => 'This page contains the start of the Design Hub page.',
+    ],
+    'dh-end' => [
+        'title' => 'Design Hub End',
+        'text'  => 'This page contains the end of the Design Hub page.',
+    ],
 
 ];

--- a/public/css/designhub.css
+++ b/public/css/designhub.css
@@ -12,9 +12,6 @@
 .flex-gap {
 	gap: 20px;
 }
-.card {
-	/* border-color: var(--dark); */
-}
 .searchContent .item {
 	width: calc(33% - 10px);
 	background-color: rgba(255,255,255,0.05);
@@ -22,7 +19,6 @@
 	border-radius: 20px;
 }
 .card-header {
-	/* background-color: var(--dark); */
 	font-weight: 700;
 	font-size: 18px;
 }
@@ -58,9 +54,6 @@
 }
 .card.rounded {
 	border-radius: 20px !important;
-}
-.card-header {
-	/* background-color: var(--dark); */
 }
 .flex-gap {
 	gap: 10px;

--- a/public/css/designhub.css
+++ b/public/css/designhub.css
@@ -13,7 +13,7 @@
 	gap: 20px;
 }
 .card {
-	border-color: var(--dark);
+	/* border-color: var(--dark); */
 }
 .searchContent .item {
 	width: calc(33% - 10px);
@@ -22,7 +22,7 @@
 	border-radius: 20px;
 }
 .card-header {
-	background-color: var(--dark);
+	/* background-color: var(--dark); */
 	font-weight: 700;
 	font-size: 18px;
 }
@@ -60,7 +60,7 @@
 	border-radius: 20px !important;
 }
 .card-header {
-	background-color: var(--dark);
+	/* background-color: var(--dark); */
 }
 .flex-gap {
 	gap: 10px;

--- a/resources/views/designhub/basespage.blade.php
+++ b/resources/views/designhub/basespage.blade.php
@@ -13,7 +13,7 @@
 
     <div class="card rounded my-4">
         <div class="card-body">
-            <input type="text" placeholder="Search base coats..." class="searchBar bg-dark rounded border-0 mb-4 form-control" data-id="baseSearch" />
+            <input type="text" placeholder="Search base coats..." class="searchBar rounded border-0 mb-4 form-control" data-id="baseSearch" />
 
             <div class="d-flex flex-wrap justify-content-between searchContent base-card-container" data-id="baseSearch">
                 @if ($bases)

--- a/resources/views/designhub/basespage.blade.php
+++ b/resources/views/designhub/basespage.blade.php
@@ -13,12 +13,12 @@
 
     <div class="card rounded my-4">
         <div class="card-body">
-            <input type="text" placeholder="Search base coats..." class="searchBar rounded border-0 mb-4 form-control" data-id="baseSearch" />
+            <input type="text" placeholder="Search base coats..." class="searchBar rounded mb-4 form-control" data-id="baseSearch" />
 
             <div class="d-flex flex-wrap justify-content-between searchContent base-card-container" data-id="baseSearch">
                 @if ($bases)
                     @foreach ($bases as $base)
-                        <div class="card rounded mb-4 bg-dark">
+                        <div class="card rounded mb-4">
                             <div class="card-body">
                                 <div class="text-center">
                                     <?php

--- a/resources/views/designhub/designhub.blade.php
+++ b/resources/views/designhub/designhub.blade.php
@@ -164,8 +164,8 @@ Design Hub
         $('.searchBar').on('keyup', function(e) {
             var sTerm = $(this).val().toLowerCase();
             var type = $(this).attr('data-id');
-            console.log(type)
-            console.log(sTerm);
+            //console.log(type)
+            //console.log(sTerm);
             $('.searchContent[data-id="' + type + '"]').children().each(function() {
                 console.log($(this))
                 $(this).toggle($(this).text().toLowerCase().indexOf(sTerm) > -1);

--- a/resources/views/designhub/designhub.blade.php
+++ b/resources/views/designhub/designhub.blade.php
@@ -10,19 +10,19 @@
     {!! breadcrumbs(['Design Hub' => 'Design Hub']) !!}
     <h1>Design Hub</h1>
 
-    @if($dh_start)
-    <div class="card rounded mb-4">
-        <div class="card-header">
-            {!! $dh_start->title !!}
+    @if ($dh_start)
+        <div class="card rounded mb-4">
+            <div class="card-header">
+                {!! $dh_start->title !!}
+            </div>
+            <div class="card-body">
+                {!! $dh_start->text !!}
+            </div>
         </div>
-        <div class="card-body">
-            {!! $dh_start->text !!}
-        </div>
-    </div>
     @elseif(!$dh_start && Auth::user()->isStaff)
-    <div class="alert alert-warning" role="alert">
-        Page for design hub start is missing. Please run <code>php artisan add-text-pages</code>. This message is only visible to staff.
-    </div>
+        <div class="alert alert-warning" role="alert">
+            Page for design hub start is missing. Please run <code>php artisan add-text-pages</code>. This message is only visible to staff.
+        </div>
     @endif
 
     <div class="card rounded mb-4">
@@ -132,19 +132,19 @@
         </div>
     </div>
 
-    @if($dh_end)
-    <div class="card rounded mb-4">
-        <div class="card-header">
-            {!! $dh_end->title !!}
+    @if ($dh_end)
+        <div class="card rounded mb-4">
+            <div class="card-header">
+                {!! $dh_end->title !!}
+            </div>
+            <div class="card-body">
+                {!! $dh_end->text !!}
+            </div>
         </div>
-        <div class="card-body">
-            {!! $dh_end->text !!}
-        </div>
-    </div>
     @elseif(!$dh_end && Auth::user()->isStaff)
-    <div class="alert alert-warning" role="alert">
-        Page for design hub end is missing. Please run <code>php artisan add-text-pages</code>. This message is only visible to staff.
-    </div>
+        <div class="alert alert-warning" role="alert">
+            Page for design hub end is missing. Please run <code>php artisan add-text-pages</code>. This message is only visible to staff.
+        </div>
     @endif
 
 

--- a/resources/views/designhub/designhub.blade.php
+++ b/resources/views/designhub/designhub.blade.php
@@ -2,7 +2,7 @@
 
 
 @section('title')
-Design Hub
+    Design Hub
 @endsection
 
 
@@ -40,23 +40,23 @@ Design Hub
             <input type="text" placeholder="Search markings by name or code..." class="searchBar rounded mb-4 form-control" data-id="markingSearch" />
 
             @if ($rarity_list)
-            @foreach ($markings as $rarityId => $markingItems)
-            <div class="card rounded mb-4">
-                <div class="card-header"><span class="rarity-indicator" style="background-color:#{{ $rarity_list[$rarityId]->color }}"></span> {{ $rarity_list[$rarityId]->name }} Markings</div>
-                <div class="card-body">
-                    <div class="d-flex flex-wrap justify-content-between searchContent" data-id="markingSearch">
-                        @foreach ($markingItems as $marking)
-                        @include('designhub._entry', [
-                        'imageUrl' => file_exists($marking->imageDirectory . '/' . $marking->imageFileName) ? asset($marking->imageDirectory . '/' . $marking->imageFileName) : '/images/account.png',
-                        'name' => $marking->name . ' (' . $marking->recessive . '/' . $marking->dominant . ')',
-                        'description' => $marking->short_description,
-                        'url' => 'design-hub/marking/' . $marking->slug,
-                        ])
-                        @endforeach
+                @foreach ($markings as $rarityId => $markingItems)
+                    <div class="card rounded mb-4">
+                        <div class="card-header"><span class="rarity-indicator" style="background-color:#{{ $rarity_list[$rarityId]->color }}"></span> {{ $rarity_list[$rarityId]->name }} Markings</div>
+                        <div class="card-body">
+                            <div class="d-flex flex-wrap justify-content-between searchContent" data-id="markingSearch">
+                                @foreach ($markingItems as $marking)
+                                    @include('designhub._entry', [
+                                        'imageUrl' => file_exists($marking->imageDirectory . '/' . $marking->imageFileName) ? asset($marking->imageDirectory . '/' . $marking->imageFileName) : '/images/account.png',
+                                        'name' => $marking->name . ' (' . $marking->recessive . '/' . $marking->dominant . ')',
+                                        'description' => $marking->short_description,
+                                        'url' => 'design-hub/marking/' . $marking->slug,
+                                    ])
+                                @endforeach
+                            </div>
+                        </div>
                     </div>
-                </div>
-            </div>
-            @endforeach
+                @endforeach
             @endif
         </div>
     </div>
@@ -72,34 +72,34 @@ Design Hub
                 <div class="card-body">
                     <div class="d-flex flex-wrap justify-content-between searchContent" data-id="traits">
                         @if ($trait_lists)
-                        {!! $trait_lists->render() !!}
-                        @foreach ($trait_lists as $trait)
-                        <?php
-                        $text = $trait->description;
-                        $short_description = '';
+                            {!! $trait_lists->render() !!}
+                            @foreach ($trait_lists as $trait)
+                                <?php
+                                $text = $trait->description;
+                                $short_description = '';
+                                
+                                if ($text) {
+                                    $dom = new DOMDocument();
+                                    libxml_use_internal_errors(true);
+                                    $dom->loadHTML($text);
+                                    libxml_clear_errors();
+                                
+                                    $paragraphs = $dom->getElementsByTagName('p');
+                                
+                                    if ($paragraphs->length > 0) {
+                                        $short_description = $paragraphs->item(0)->textContent; // Get the text content of the first <p> tag
+                                    }
+                                }
+                                ?>
 
-                        if ($text) {
-                            $dom = new DOMDocument();
-                            libxml_use_internal_errors(true);
-                            $dom->loadHTML($text);
-                            libxml_clear_errors();
-
-                            $paragraphs = $dom->getElementsByTagName('p');
-
-                            if ($paragraphs->length > 0) {
-                                $short_description = $paragraphs->item(0)->textContent; // Get the text content of the first <p> tag
-                            }
-                        }
-                        ?>
-
-                        @include('designhub._entry', [
-                        'imageUrl' => $trait->imageUrl ?? '/images/account.png',
-                        'name' => $trait->name,
-                        'description' => $short_description ?? '',
-                        'url' => $trait->getUrlAttribute() ?: '/world/traits?name=' . $trait->name,
-                        ])
-                        @endforeach
-                        {!! $trait_lists->render() !!}
+                                @include('designhub._entry', [
+                                    'imageUrl' => $trait->imageUrl ?? '/images/account.png',
+                                    'name' => $trait->name,
+                                    'description' => $short_description ?? '',
+                                    'url' => $trait->getUrlAttribute() ?: '/world/traits?name=' . $trait->name,
+                                ])
+                            @endforeach
+                            {!! $trait_lists->render() !!}
                         @endif
                     </div>
                 </div>
@@ -113,28 +113,28 @@ Design Hub
         </div>
         <div class="card-body">
             @foreach ($specieses as $species)
-            <div class="card rounded mb-4">
-                <div class="card-header">{{ $species->name }} Templates</div>
-                <div class="card-body">
-                    <div class="d-flex flex-wrap flex-column justify-content-between">
-                        @foreach ($subtypes as $subtype)
-                        @if ($subtype->species_id === $species->id)
-                        <div class="card item flex-fill my-2">
-                            <div class="card-body">
-                                @if ($subtype->subtypeImageUrl)
-                                <a href="{{ $subtype->subtypeImageUrl }}" data-lightbox="entry" data-title="{{ $subtype->name }}">
-                                    <img src="{{ $subtype->subtypeImageUrl }}" class="world-entry-image" alt="{{ $subtype->name }}" />
-                                </a>
+                <div class="card rounded mb-4">
+                    <div class="card-header">{{ $species->name }} Templates</div>
+                    <div class="card-body">
+                        <div class="d-flex flex-wrap flex-column justify-content-between">
+                            @foreach ($subtypes as $subtype)
+                                @if ($subtype->species_id === $species->id)
+                                    <div class="card item flex-fill my-2">
+                                        <div class="card-body">
+                                            @if ($subtype->subtypeImageUrl)
+                                                <a href="{{ $subtype->subtypeImageUrl }}" data-lightbox="entry" data-title="{{ $subtype->name }}">
+                                                    <img src="{{ $subtype->subtypeImageUrl }}" class="world-entry-image" alt="{{ $subtype->name }}" />
+                                                </a>
+                                            @endif
+                                            <h3>{{ $subtype->name }}</h3>
+                                            <p>{!! $subtype->description !!}</p>
+                                        </div>
+                                    </div>
                                 @endif
-                                <h3>{{ $subtype->name }}</h3>
-                                <p>{!! $subtype->description !!}</p>
-                            </div>
+                            @endforeach
                         </div>
-                        @endif
-                        @endforeach
                     </div>
                 </div>
-            </div>
             @endforeach
         </div>
     </div>
@@ -158,19 +158,19 @@ Design Hub
 @endsection
 
 @section('scripts')
-@parent
-<script>
-    $(document).ready(function() {
-        $('.searchBar').on('keyup', function(e) {
-            var sTerm = $(this).val().toLowerCase();
-            var type = $(this).attr('data-id');
-            console.log(type)
-            console.log(sTerm);
-            $('.searchContent[data-id="' + type + '"]').children().each(function() {
-                console.log($(this))
-                $(this).toggle($(this).text().toLowerCase().indexOf(sTerm) > -1);
+    @parent
+    <script>
+        $(document).ready(function() {
+            $('.searchBar').on('keyup', function(e) {
+                var sTerm = $(this).val().toLowerCase();
+                var type = $(this).attr('data-id');
+                console.log(type)
+                console.log(sTerm);
+                $('.searchContent[data-id="' + type + '"]').children().each(function() {
+                    console.log($(this))
+                    $(this).toggle($(this).text().toLowerCase().indexOf(sTerm) > -1);
+                });
             });
         });
-    });
-</script>
+    </script>
 @endsection

--- a/resources/views/designhub/designhub.blade.php
+++ b/resources/views/designhub/designhub.blade.php
@@ -2,168 +2,175 @@
 
 
 @section('title')
-    Design Hub
+Design Hub
 @endsection
 
 
 @section('content')
-    {!! breadcrumbs(['Design Hub' => 'Design Hub']) !!}
-    <h1>Design Hub</h1>
+{!! breadcrumbs(['Design Hub' => 'Design Hub']) !!}
+<h1>Design Hub</h1>
 
-    @if($dh_start)
-    <div class="card rounded mb-4">
-        <div class="card-header">
-            {!! $dh_start->title !!}
-        </div>
-        <div class="card-body">
-            {!! $dh_start->text !!}
-        </div>
+@if($dh_start)
+<div class="card rounded mb-4">
+    <div class="card-header">
+        {!! $dh_start->title !!}
     </div>
-    @elseif(!$dh_start && Auth::user()->isStaff)
-    <div class="alert alert-warning" role="alert">
-        Page for design hub start is missing. Please run <code>php artisan add-text-pages</code>. This message is only visible to staff.
+    <div class="card-body">
+        {!! $dh_start->text !!}
     </div>
-    @endif
+</div>
+@elseif(!$dh_start && Auth::user()->isStaff)
+<div class="alert alert-warning" role="alert">
+    Page for design hub start is missing. Please run <code>php artisan add-text-pages</code>. This message is only visible to staff.
+</div>
+@endif
 
-    <div class="card rounded mb-4">
-        <div class="card-header">
-            Markings
-        </div>
-        <div class="card-body">
-            <input type="text" placeholder="Search markings by name or code..." class="searchBar rounded mb-4 form-control" data-id="markingSearch" />
+<div class="row mb-4">
+    <div class="col d-flex"><a href="#markings" class="btn btn-primary">Markings</a></div>
+    <div class="col d-flex"><a href="#traitguides" class="btn btn-primary">Trait Guides</a></div>
+    <div class="col d-flex"><a href="#importtemplates" class="btn btn-primary">Import Templates</a></div>
+    <div class="col d-flex"><a href="{{ url('design-hub/base-coats') }}" class="btn btn-primary">Base Coats</a></div>
+</div>
 
-            @if ($rarity_list)
-                @foreach ($markings as $rarityId => $markingItems)
-                    <div class="card rounded mb-4">
-                        <div class="card-header"><span class="rarity-indicator" style="background-color:#{{ $rarity_list[$rarityId]->color }}"></span> {{ $rarity_list[$rarityId]->name }} Markings</div>
-                        <div class="card-body">
-                            <div class="d-flex flex-wrap justify-content-between searchContent" data-id="markingSearch">
-                                @foreach ($markingItems as $marking)
-                                    @include('designhub._entry', [
-                                        'imageUrl' => file_exists($marking->imageDirectory . '/' . $marking->imageFileName) ? asset($marking->imageDirectory . '/' . $marking->imageFileName) : '/images/account.png',
-                                        'name' => $marking->name . ' (' . $marking->recessive . '/' . $marking->dominant . ')',
-                                        'description' => $marking->short_description,
-                                        'url' => 'design-hub/marking/' . $marking->slug,
-                                    ])
-                                @endforeach
-                            </div>
-                        </div>
-                    </div>
-                @endforeach
-            @endif
-        </div>
+<div class="card rounded mb-4" id="markings">
+    <div class="card-header">
+        Markings
     </div>
+    <div class="card-body">
+        <input type="text" placeholder="Search markings by name or code..." class="searchBar rounded mb-4 form-control" data-id="markingSearch" />
 
-    <div class="card rounded mb-4">
-        <div class="card-header">
-            Trait Guides
+        @if ($rarity_list)
+        @foreach ($markings as $rarityId => $markingItems)
+        <div class="card rounded mb-4">
+            <div class="card-header"><span class="rarity-indicator" style="background-color:#{{ $rarity_list[$rarityId]->color }}"></span> {{ $rarity_list[$rarityId]->name }} Markings</div>
+            <div class="card-body">
+                <div class="d-flex flex-wrap justify-content-between searchContent" data-id="markingSearch">
+                    @foreach ($markingItems as $marking)
+                    @include('designhub._entry', [
+                    'imageUrl' => file_exists($marking->imageDirectory . '/' . $marking->imageFileName) ? asset($marking->imageDirectory . '/' . $marking->imageFileName) : '/images/account.png',
+                    'name' => $marking->name . ' (' . $marking->recessive . '/' . $marking->dominant . ')',
+                    'description' => $marking->short_description,
+                    'url' => 'design-hub/marking/' . $marking->slug,
+                    ])
+                    @endforeach
+                </div>
+            </div>
         </div>
-        <div class="card-body">
-            <input type="text" placeholder="Search traits..." class="searchBar rounded mb-4 form-control" data-id="traits" />
-            <div class="card rounded mb-4">
-                <div class="card-header">Trait Guides</div>
-                <div class="card-body">
-                    <div class="d-flex flex-wrap justify-content-between searchContent" data-id="traits">
-                        @if ($trait_lists)
-                            {!! $trait_lists->render() !!}
-                            @foreach ($trait_lists as $trait)
-                                <?php
-                                $text = $trait->description;
-                                $short_description = '';
-                                
-                                if ($text) {
-                                    $dom = new DOMDocument();
-                                    libxml_use_internal_errors(true);
-                                    $dom->loadHTML($text);
-                                    libxml_clear_errors();
-                                
-                                    $paragraphs = $dom->getElementsByTagName('p');
-                                
-                                    if ($paragraphs->length > 0) {
-                                        $short_description = $paragraphs->item(0)->textContent; // Get the text content of the first <p> tag
-                                    }
-                                }
-                                ?>
+        @endforeach
+        @endif
+    </div>
+</div>
 
-                                @include('designhub._entry', [
-                                    'imageUrl' => $trait->imageUrl ?? '/images/account.png',
-                                    'name' => $trait->name,
-                                    'description' => $short_description ?? '',
-                                    'url' => $trait->getUrlAttribute() ?: '/world/traits?name=' . $trait->name,
-                                ])
-                            @endforeach
-                            {!! $trait_lists->render() !!}
-                        @endif
-                    </div>
+<div class="card rounded mb-4" id="traitguides">
+    <div class="card-header">
+        Trait Guides
+    </div>
+    <div class="card-body">
+        <input type="text" placeholder="Search traits..." class="searchBar rounded mb-4 form-control" data-id="traits" />
+        <div class="card rounded mb-4">
+            <div class="card-header">Trait Guides</div>
+            <div class="card-body">
+                <div class="d-flex flex-wrap justify-content-between searchContent" data-id="traits">
+                    @if ($trait_lists)
+                    {!! $trait_lists->render() !!}
+                    @foreach ($trait_lists as $trait)
+                    <?php
+                    $text = $trait->description;
+                    $short_description = '';
+
+                    if ($text) {
+                        $dom = new DOMDocument();
+                        libxml_use_internal_errors(true);
+                        $dom->loadHTML($text);
+                        libxml_clear_errors();
+
+                        $paragraphs = $dom->getElementsByTagName('p');
+
+                        if ($paragraphs->length > 0) {
+                            $short_description = $paragraphs->item(0)->textContent; // Get the text content of the first <p> tag
+                        }
+                    }
+                    ?>
+
+                    @include('designhub._entry', [
+                    'imageUrl' => $trait->imageUrl ?? '/images/account.png',
+                    'name' => $trait->name,
+                    'description' => $short_description ?? '',
+                    'url' => $trait->getUrlAttribute() ?: '/world/traits?name=' . $trait->name,
+                    ])
+                    @endforeach
+                    {!! $trait_lists->render() !!}
+                    @endif
                 </div>
             </div>
         </div>
     </div>
+</div>
 
-    <div class="card rounded mb-4">
-        <div class="card-header">
-            Import Templates
-        </div>
-        <div class="card-body">
-            @foreach ($specieses as $species)
-                <div class="card rounded mb-4">
-                    <div class="card-header">{{ $species->name }} Templates</div>
-                    <div class="card-body">
-                        <div class="d-flex flex-wrap flex-column justify-content-between">
-                            @foreach ($subtypes as $subtype)
-                                @if ($subtype->species_id === $species->id)
-                                    <div class="card item flex-fill my-2">
-                                        <div class="card-body">
-                                            @if ($subtype->subtypeImageUrl)
-                                                <a href="{{ $subtype->subtypeImageUrl }}" data-lightbox="entry" data-title="{{ $subtype->name }}">
-                                                    <img src="{{ $subtype->subtypeImageUrl }}" class="world-entry-image" alt="{{ $subtype->name }}" />
-                                                </a>
-                                            @endif
-                                            <h3>{{ $subtype->name }}</h3>
-                                            <p>{!! $subtype->description !!}</p>
-                                        </div>
-                                    </div>
-                                @endif
-                            @endforeach
+<div class="card rounded mb-4" id="importtemplates">
+    <div class="card-header">
+        Import Templates
+    </div>
+    <div class="card-body">
+        @foreach ($specieses as $species)
+        <div class="card rounded mb-4">
+            <div class="card-header">{{ $species->name }} Templates</div>
+            <div class="card-body">
+                <div class="d-flex flex-wrap flex-column justify-content-between">
+                    @foreach ($subtypes as $subtype)
+                    @if ($subtype->species_id === $species->id)
+                    <div class="card item flex-fill my-2">
+                        <div class="card-body">
+                            @if ($subtype->subtypeImageUrl)
+                            <a href="{{ $subtype->subtypeImageUrl }}" data-lightbox="entry" data-title="{{ $subtype->name }}">
+                                <img src="{{ $subtype->subtypeImageUrl }}" class="world-entry-image" alt="{{ $subtype->name }}" />
+                            </a>
+                            @endif
+                            <h3>{{ $subtype->name }}</h3>
+                            <p>{!! $subtype->description !!}</p>
                         </div>
                     </div>
+                    @endif
+                    @endforeach
                 </div>
-            @endforeach
+            </div>
         </div>
+        @endforeach
     </div>
+</div>
 
-    @if($dh_end)
-    <div class="card rounded mb-4">
-        <div class="card-header">
-            {!! $dh_end->title !!}
-        </div>
-        <div class="card-body">
-            {!! $dh_end->text !!}
-        </div>
+@if($dh_end)
+<div class="card rounded mb-4">
+    <div class="card-header">
+        {!! $dh_end->title !!}
     </div>
-    @elseif(!$dh_end && Auth::user()->isStaff)
-    <div class="alert alert-warning" role="alert">
-        Page for design hub end is missing. Please run <code>php artisan add-text-pages</code>. This message is only visible to staff.
+    <div class="card-body">
+        {!! $dh_end->text !!}
     </div>
-    @endif
+</div>
+@elseif(!$dh_end && Auth::user()->isStaff)
+<div class="alert alert-warning" role="alert">
+    Page for design hub end is missing. Please run <code>php artisan add-text-pages</code>. This message is only visible to staff.
+</div>
+@endif
 
 
 @endsection
 
 @section('scripts')
-    @parent
-    <script>
-        $(document).ready(function() {
-            $('.searchBar').on('keyup', function(e) {
-                var sTerm = $(this).val().toLowerCase();
-                var type = $(this).attr('data-id');
-                console.log(type)
-                console.log(sTerm);
-                $('.searchContent[data-id="' + type + '"]').children().each(function() {
-                    console.log($(this))
-                    $(this).toggle($(this).text().toLowerCase().indexOf(sTerm) > -1);
-                });
+@parent
+<script>
+    $(document).ready(function() {
+        $('.searchBar').on('keyup', function(e) {
+            var sTerm = $(this).val().toLowerCase();
+            var type = $(this).attr('data-id');
+            console.log(type)
+            console.log(sTerm);
+            $('.searchContent[data-id="' + type + '"]').children().each(function() {
+                console.log($(this))
+                $(this).toggle($(this).text().toLowerCase().indexOf(sTerm) > -1);
             });
         });
-    </script>
+    });
+</script>
 @endsection

--- a/resources/views/designhub/designhub.blade.php
+++ b/resources/views/designhub/designhub.blade.php
@@ -24,23 +24,21 @@
             Markings
         </div>
         <div class="card-body">
-            <input type="text" placeholder="Search markings by name or code..." class="searchBar bg-dark rounded border-0 mb-4 form-control" data-id="markingSearch" />
+            <input type="text" placeholder="Search markings by name or code..." class="searchBar rounded mb-4 form-control" data-id="markingSearch" />
 
             @if ($rarity_list)
-                @foreach ($rarity_list as $rarity_item)
+                @foreach ($markings as $rarityId => $markingItems)
                     <div class="card rounded mb-4">
-                        <div class="card-header"><span class="rarity-indicator" style="background-color:#{{ $rarity_item->color }}"></span> {{ $rarity_item->name }} Markings</div>
+                        <div class="card-header"><span class="rarity-indicator" style="background-color:#{{ $rarity_list[$rarityId]->color }}"></span> {{ $rarity_list[$rarityId]->name }} Markings</div>
                         <div class="card-body">
                             <div class="d-flex flex-wrap justify-content-between searchContent" data-id="markingSearch">
-                                @foreach ($markings as $marking)
-                                    @if ($marking->rarity_id === $rarity_item->id)
-                                        @include('designhub._entry', [
-                                            'imageUrl' => file_exists($marking->imageDirectory . '/' . $marking->imageFileName) ? asset($marking->imageDirectory . '/' . $marking->imageFileName) : '/images/account.png',
-                                            'name' => $marking->name . ' (' . $marking->recessive . '/' . $marking->dominant . ')',
-                                            'description' => $marking->short_description,
-                                            'url' => 'design-hub/marking/' . $marking->slug,
-                                        ])
-                                    @endif
+                                @foreach ($markingItems as $marking)
+                                    @include('designhub._entry', [
+                                        'imageUrl' => file_exists($marking->imageDirectory . '/' . $marking->imageFileName) ? asset($marking->imageDirectory . '/' . $marking->imageFileName) : '/images/account.png',
+                                        'name' => $marking->name . ' (' . $marking->recessive . '/' . $marking->dominant . ')',
+                                        'description' => $marking->short_description,
+                                        'url' => 'design-hub/marking/' . $marking->slug,
+                                    ])
                                 @endforeach
                             </div>
                         </div>
@@ -55,7 +53,7 @@
             Trait Guides
         </div>
         <div class="card-body">
-            <input type="text" placeholder="Search traits..." class="searchBar bg-dark rounded border-0 mb-4 form-control" data-id="traits" />
+            <input type="text" placeholder="Search traits..." class="searchBar rounded mb-4 form-control" data-id="traits" />
             <div class="card rounded mb-4">
                 <div class="card-header">Trait Guides</div>
                 <div class="card-body">

--- a/resources/views/designhub/designhub.blade.php
+++ b/resources/views/designhub/designhub.blade.php
@@ -10,6 +10,7 @@
     {!! breadcrumbs(['Design Hub' => 'Design Hub']) !!}
     <h1>Design Hub</h1>
 
+    @if($dh_start)
     <div class="card rounded mb-4">
         <div class="card-header">
             {!! $dh_start->title !!}
@@ -18,6 +19,11 @@
             {!! $dh_start->text !!}
         </div>
     </div>
+    @elseif(!$dh_start && Auth::user()->isStaff)
+    <div class="alert alert-warning" role="alert">
+        Page for design hub start is missing. Please run <code>php artisan add-text-pages</code>. This message is only visible to staff.
+    </div>
+    @endif
 
     <div class="card rounded mb-4">
         <div class="card-header">
@@ -126,6 +132,7 @@
         </div>
     </div>
 
+    @if($dh_end)
     <div class="card rounded mb-4">
         <div class="card-header">
             {!! $dh_end->title !!}
@@ -134,6 +141,12 @@
             {!! $dh_end->text !!}
         </div>
     </div>
+    @elseif(!$dh_end && Auth::user()->isStaff)
+    <div class="alert alert-warning" role="alert">
+        Page for design hub end is missing. Please run <code>php artisan add-text-pages</code>. This message is only visible to staff.
+    </div>
+    @endif
+
 
 @endsection
 

--- a/resources/views/designhub/designhub.blade.php
+++ b/resources/views/designhub/designhub.blade.php
@@ -161,15 +161,13 @@
     @parent
     <script>
         $(document).ready(function() {
-                    $('.searchBar').on('keyup', function(e) {
-                        var sTerm = $(this).val().toLowerCase();
-                        var type = $(this).attr('data-id');
-                        //console.log(type)
-                        //console.log(sTerm);
-                        $('.searchContent[data-id="' + type + '"]').children().each(function() {
-                            console.log($(this))
-                            $(this).toggle($(this).text().toLowerCase().indexOf(sTerm) > -1);
-                        });
-                    });
+            $('.searchBar').on('keyup', function(e) {
+                var sTerm = $(this).val().toLowerCase();
+                var type = $(this).attr('data-id');
+                $('.searchContent[data-id="' + type + '"]').children().each(function() {
+                    $(this).toggle($(this).text().toLowerCase().indexOf(sTerm) > -1);
+                });
+            });
+        });
     </script>
 @endsection

--- a/resources/views/designhub/designhub.blade.php
+++ b/resources/views/designhub/designhub.blade.php
@@ -158,18 +158,18 @@
 @endsection
 
 @section('scripts')
-@parent
-<script>
-    $(document).ready(function() {
-        $('.searchBar').on('keyup', function(e) {
-            var sTerm = $(this).val().toLowerCase();
-            var type = $(this).attr('data-id');
-            //console.log(type)
-            //console.log(sTerm);
-            $('.searchContent[data-id="' + type + '"]').children().each(function() {
-                console.log($(this))
-                $(this).toggle($(this).text().toLowerCase().indexOf(sTerm) > -1);
-            });
-        });
+    @parent
+    <script>
+        $(document).ready(function() {
+                    $('.searchBar').on('keyup', function(e) {
+                        var sTerm = $(this).val().toLowerCase();
+                        var type = $(this).attr('data-id');
+                        //console.log(type)
+                        //console.log(sTerm);
+                        $('.searchContent[data-id="' + type + '"]').children().each(function() {
+                            console.log($(this))
+                            $(this).toggle($(this).text().toLowerCase().indexOf(sTerm) > -1);
+                        });
+                    });
     </script>
 @endsection


### PR DESCRIPTION
- Slightly optimizes markings page queries and for loops (prevents cycling through the entire marking list for each rarity)
- Correctly reflect the rarity sort values
- Makes the site page query a single one because why not -- saves making an extra DB call and this page is liable to have rather hefty queries
- Adds dh-end and dh-start to the add-text-pages command (much like Donation Shop does)
- Shows a staff-only warning message if dh-end and dh-start are missing, in place of the previous 500 error
- Makes the styling of design hub line up with core's styling (this is best practice)
- Adds a "menu" to design hub to easily jump to different sections, as well as a direct link to the base coats page (I considered adding a section for base coats directly onto the design hub page, but it's be liable to make it really long...)

Please let me know if any of these changes are too opinionated! You've made a great extension and thank you for giving me the opportunity to contribute!