### PR TITLE
make design queue public

### DIFF
--- a/app/Console/Commands/AddSiteSettings.php
+++ b/app/Console/Commands/AddSiteSettings.php
@@ -83,6 +83,8 @@ class AddSiteSettings extends Command {
 
         $this->addSiteSetting('comment_dislikes_enabled', 0, '0: Dislikes disabled, 1: Dislikes enabled.');
 
+        $this->addSiteSetting('is_design_queue_public', 0, '0: Design queue is hidden, 1: Design queue is public.');
+
         $this->line("\nSite settings up to date!");
     }
 

--- a/app/Console/Commands/AddSiteSettings.php
+++ b/app/Console/Commands/AddSiteSettings.php
@@ -83,7 +83,7 @@ class AddSiteSettings extends Command {
 
         $this->addSiteSetting('comment_dislikes_enabled', 0, '0: Dislikes disabled, 1: Dislikes enabled.');
 
-        $this->addSiteSetting('is_design_queue_public', 0, '0: Design queue is hidden, 1: Design queue is public.');
+        $this->addSiteSetting('is_design_queue_public', 1, '0: Design queue is hidden, 1: Design queue is public.');
 
         $this->line("\nSite settings up to date!");
     }

--- a/app/Http/Controllers/QueueController.php
+++ b/app/Http/Controllers/QueueController.php
@@ -3,8 +3,8 @@
 namespace App\Http\Controllers;
 
 use App\Models\Prompt\PromptCategory;
-// use App\Http\Controllers\Controller;
 use App\Models\Submission\Submission;
+use App\Models\Character\CharacterDesignUpdate;
 use Illuminate\Http\Request;
 
 class QueueController extends Controller {
@@ -17,6 +17,7 @@ class QueueController extends Controller {
      */
     public function getQueueIndex(Request $request, $status = null) {
         $submissions = Submission::with('prompt')->where('status', $status ? ucfirst($status) : 'Pending')->whereNotNull('prompt_id');
+        $designs = CharacterDesignUpdate::where('status', $status ? ucfirst($status) :'Pending');
         $data = $request->only(['prompt_category_id', 'sort']);
         if (isset($data['prompt_category_id']) && $data['prompt_category_id'] != 'none') {
             $submissions->whereHas('prompt', function ($query) use ($data) {
@@ -42,6 +43,7 @@ class QueueController extends Controller {
 
         return view('queues.queues', [
             'submissions' => $submissions->paginate(30)->appends($request->query()),
+            'designs'     => $designs ->paginate(30)->appends($request->query()),
             'categories'  => ['none' => 'Any Category'] + PromptCategory::orderBy('sort', 'DESC')->pluck('name', 'id')->toArray(),
             'isClaims'    => false,
         ]);

--- a/resources/views/queues/queues.blade.php
+++ b/resources/views/queues/queues.blade.php
@@ -1,3 +1,4 @@
+
 @extends('queues.layout')
 
 @section('queues-title')
@@ -8,76 +9,102 @@
     {!! breadcrumbs(['Queues' => 'queues', 'All Queues' => 'queues/queues']) !!}
     <h1>All Queues</h1>
 
-    <div>
-        {!! Form::open(['method' => 'GET', 'class' => '']) !!}
-        <div class="form-inline justify-content-end">
-            <div class="form-group ml-3 mb-3">
-                {!! Form::select('prompt_category_id', $categories, Request::get('prompt_category_id'), ['class' => 'form-control']) !!}
-            </div>
-            <div class="form-inline justify-content-end">
-                <div class="form-group ml-3 mb-3">
-                    {!! Form::submit('Search', ['class' => 'btn btn-primary']) !!}
-                </div>
-            </div>
-            {!! Form::close() !!}
-        </div>
+    {!! $submissions->render() !!}
 
-        {!! $submissions->render() !!}
-        <div class="mb-4 logs-table">
-            <div class="logs-table-header">
-                <div class="row">
-                    @if (!$isClaims)
-                        <div class="col-12 col-md-2">
-                            <div class="logs-table-cell">Prompt</div>
+    <ul class="nav nav-tabs card-header-tabs">
+        <li class="nav-item">
+            <a class="nav-link active" id="promptTab" data-toggle="tab" href="#prompts" role="tab">Prompts</a>
+        </li>
+        @if (Settings::get('is_design_queue_public'))
+            <li class="nav-item">
+                <a class="nav-link" id="designsTab" data-toggle="tab" href="#designs" role="tab">Designs</a>
+            </li>
+        @endif
+    </ul>
+    <!-- PROMPTS TAB -->
+    <div class="card-body tab-content">
+        <div class="tab-pane fade show active" id="prompts">
+            <div>
+                {!! Form::open(['method' => 'GET', 'class' => '']) !!}
+                    <div class="form-inline justify-content-end">
+                        <div class="form-group ml-3 mb-3">
+                            {!! Form::select('prompt_category_id', $categories, Request::get('prompt_category_id'), ['class' => 'form-control']) !!}
                         </div>
-                        <div class="col-6 {{ !$isClaims ? 'col-md-2' : 'col-md-3' }}">
-                            <div class="logs-table-cell">User</div>
+                        <div class="form-group ml-3 mb-3">
+                            {!! Form::submit('Search', ['class' => 'btn btn-primary']) !!}
                         </div>
-                        <div class="col-6 {{ !$isClaims ? 'col-md-3' : 'col-md-4' }}">
-                            <div class="logs-table-cell">Link</div>
-                        </div>
-                        <div class="col-6 col-md-3">
-                            <div class="logs-table-cell">Submitted</div>
-                        </div>
-                        <div class="col-6 col-md-1">
-                            <div class="logs-table-cell">Status</div>
-                        </div>
-                    @endif
-                </div>
-            </div>
-            <div class="logs-table-body">
-                @foreach ($submissions as $submission)
-                    <div class="logs-table-row" style="{{ $submission->user->id == Auth::user()->id ? 'background-color:rgba(48, 121, 240, 0.1);' : '' }}">
-                        <div class="row flex-wrap">
+                    </div>
+                {!! Form::close() !!} 
+                
+                {!! $submissions->render() !!}
+
+                <div class="mb-4 logs-table">
+                    <div class="logs-table-header">
+                        <div class="row">
                             @if (!$isClaims)
-                                <div class="col-12 col-md-2">
-                                    <div class="logs-table-cell">{!! $submission->prompt->displayName !!}</div>
-                                </div>
-                                <div class="col-6 {{ !$isClaims ? 'col-md-2' : 'col-md-3' }}">
-                                    <div class="logs-table-cell">{!! $submission->user->displayName !!}</div>
-                                </div>
-                                <div class="col-6 {{ !$isClaims ? 'col-md-3' : 'col-md-4' }}">
-                                    <div class="logs-table-cell">
-                                        <span class="ubt-texthide"><a href="{{ $submission->url }}">{{ $submission->url }}</a></span>
-                                    </div>
-                                </div>
-                                <div class="col-6 col-md-3">
-                                    <div class="logs-table-cell">{!! pretty_date($submission->created_at) !!}</div>
-                                </div>
-                                <div class="col-3 col-md-1">
-                                    <div class="logs-table-cell">
-                                        <span class="btn btn-{{ $submission->status == 'Pending' ? 'secondary' : ($submission->status == 'Approved' ? 'success' : 'danger') }} btn-sm py-0 px-1">{{ $submission->status }}</span>
-                                    </div>
-                                </div>
-                                <div class="col-3 col-md-1">
-                                    <div class="logs-table-cell"></div>
-                                </div>
+                                <div class="col-12 col-md-2"><div class="logs-table-cell">Prompt</div></div>
+                                <div class="col-6 {{ !$isClaims ? 'col-md-2' : 'col-md-3' }}"><div class="logs-table-cell">User</div></div>
+                                <div class="col-6 {{ !$isClaims ? 'col-md-3' : 'col-md-4' }}"><div class="logs-table-cell">Link</div></div>
+                                <div class="col-6 col-md-3"><div class="logs-table-cell">Submitted</div></div>
+                                <div class="col-6 col-md-1"><div class="logs-table-cell">Status</div></div>
                             @endif
                         </div>
                     </div>
-                @endforeach
+                    <div class="logs-table-body">
+                        @foreach ($submissions as $submission)
+                            <div class="logs-table-row" style="{{ $submission->user->id == Auth::user()->id ? 'background-color:rgba(48, 121, 240, 0.1);' : '' }}">
+                                <div class="row flex-wrap">
+                                    @if (!$isClaims)
+                                        <div class="col-12 col-md-2"><div class="logs-table-cell">{!! $submission->prompt->displayName !!}</div></div>
+                                        <div class="col-6 {{ !$isClaims ? 'col-md-2' : 'col-md-3' }}"><div class="logs-table-cell">{!! $submission->user->displayName !!}</div></div>
+                                        <div class="col-6 {{ !$isClaims ? 'col-md-3' : 'col-md-4' }}"><div class="logs-table-cell"><span class="ubt-texthide"><a href="{{ $submission->url }}">{{ $submission->url }}</a></span></div></div>
+                                        <div class="col-6 col-md-3"><div class="logs-table-cell">{!! pretty_date($submission->created_at) !!}</div></div>
+                                        <div class="col-3 col-md-1"><div class="logs-table-cell"><span class="btn btn-{{ $submission->status == 'Pending' ? 'secondary' : ($submission->status == 'Approved' ? 'success' : 'danger') }} btn-sm py-0 px-1">{{ $submission->status }}</span></div></div>
+                                        <div class="col-3 col-md-1"><div class="logs-table-cell"></div></div>
+                                    @endif
+                                </div>
+                            </div>
+                        @endforeach
+                    </div>
+                </div>
+            </div>
+            <div class="text-center mt-4 small text-muted">
+                {{ $submissions->total() }} result{{ $submissions->total() == 1 ? '' : 's' }} found.
             </div>
         </div>
-        {!! $submissions->render() !!}
-        <div class="text-center mt-4 small text-muted">{{ $submissions->total() }} result{{ $submissions->total() == 1 ? '' : 's' }} found.</div>
-    @endsection
+
+        <!-- DESIGNS TAB -->
+        @if (Settings::get('is_design_queue_public'))
+            <div class="tab-pane fade mt-5" id="designs">
+                {!! $designs->render() !!}
+                <div class="mb-4 logs-table">
+                    <div class="logs-table-header">
+                        <div class="row">
+                            <div class="col-6 col-md-3"><div class="logs-table-cell">Character/MYO</div></div>
+                            <div class="col-6 {{ !$isClaims ? 'col-md-2' : 'col-md-3' }}"><div class="logs-table-cell">User</div></div>
+                            <div class="col-6 col-md-3"><div class="logs-table-cell">Submitted</div></div>
+                            <div class="col-6 col-md-1"><div class="logs-table-cell">Status</div></div>
+                        </div>
+                    </div>
+                    <div class="logs-table-body">
+                        @foreach ($designs as $design)
+                            <div class="logs-table-row" style="{{ $design->user->id == Auth::user()->id ? 'background-color:rgba(48, 121, 240, 0.1);' : '' }}">
+                                <div class="row flex-wrap">
+                                    <div class="col-3 col-md-3"><div class="logs-table-cell">{!! $design->character->displayName !!}</div></div>
+                                    <div class="col-6 {{ !$isClaims ? 'col-md-2' : 'col-md-3' }}"><div class="logs-table-cell">{!! $design->user->displayName !!}</div></div>
+                                    <div class="col-6 col-md-3"><div class="logs-table-cell">{!! pretty_date($design->created_at) !!}</div></div>
+                                    <div class="col-3 col-md-1"><div class="logs-table-cell"><span class="btn btn-{{ $design->status == 'Pending' ? 'secondary' : ($design->status == 'Approved' ? 'success' : 'danger') }} btn-sm py-0 px-1">{{ $design->status }}</span></div></div>
+                                    <div class="col-3 col-md-1"><div class="logs-table-cell"></div></div>
+                                </div>
+                            </div>
+                        @endforeach
+                    </div>
+                </div>
+                <div class="text-center mt-4 small text-muted">
+                    {{ $designs->total() }} result{{ $designs->total() == 1 ? '' : 's' }} found.
+                </div>
+            </div>
+        @endif
+    </div>
+    
+@endsection


### PR DESCRIPTION
Adds design update queue to the public queues page. The queue blade needed heavily changes to accommodate a tabbed format.

There is now a site setting called "is_design_queue_public" which is default set to on/1. When off it hides the entire design queue tab.